### PR TITLE
Fixed return type bug in src/safe_bool.h

### DIFF
--- a/src/safe_bool.h
+++ b/src/safe_bool.h
@@ -79,13 +79,13 @@ public:
 // unintentionally comparing things as though they were bools.
 //
 template <typename T, typename U> 
-void operator==(const safe_bool<T>& lhs,const safe_bool<U>& rhs) {
+bool operator==(const safe_bool<T>& lhs,const safe_bool<U>& rhs) {
   lhs.this_type_does_not_support_comparisons();
   return false;
 }
 
 template <typename T,typename U> 
-void operator!=(const safe_bool<T>& lhs,const safe_bool<U>& rhs) {
+bool operator!=(const safe_bool<T>& lhs,const safe_bool<U>& rhs) {
   lhs.this_type_does_not_support_comparisons();
   return false;
 }


### PR DESCRIPTION
Fixed the following compiler warning on compile:

```
src/safe_bool.h:79:3: error: void function 'operator==' should not return a value [-Wreturn-type]
  return false;
  ^      ~~~~~
src/safe_bool.h:85:3: error: void function 'operator!=' should not return a value [-Wreturn-type]
  return false;
  ^      ~~~~~
```